### PR TITLE
SMuFL character → SMuFL glyph

### DIFF
--- a/docs/src/data/datatypes-musicxml.json
+++ b/docs/src/data/datatypes-musicxml.json
@@ -23,7 +23,7 @@
    },
    "smufl-coda-glyph-name": {
       "name": "smufl-coda-glyph-name",
-      "documentation": "The smufl-coda-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) coda character. The value is a SMuFL canonical glyph name that starts with coda.",
+      "documentation": "The smufl-coda-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) coda glyph. The value is a SMuFL canonical glyph name that starts with coda.",
       "base": [
          "smufl-glyph-name"
       ],
@@ -261,7 +261,7 @@
    },
    "smufl-accidental-glyph-name": {
       "name": "smufl-accidental-glyph-name",
-      "documentation": "The smufl-accidental-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) accidental character. The value is a SMuFL canonical glyph name that starts with one of the strings used at the start of glyph names for SMuFL accidentals.",
+      "documentation": "The smufl-accidental-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) accidental glyph. The value is a SMuFL canonical glyph name that starts with one of the strings used at the start of glyph names for SMuFL accidentals.",
       "base": [
          "smufl-glyph-name"
       ],
@@ -270,7 +270,7 @@
    },
    "smufl-pictogram-glyph-name": {
       "name": "smufl-pictogram-glyph-name",
-      "documentation": "The smufl-pictogram-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) percussion pictogram character. The value is a SMuFL canonical glyph name that starts with pict.",
+      "documentation": "The smufl-pictogram-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) percussion pictogram glyph. The value is a SMuFL canonical glyph name that starts with pict.",
       "base": [
          "smufl-glyph-name"
       ],
@@ -583,7 +583,7 @@
    },
    "smufl-segno-glyph-name": {
       "name": "smufl-segno-glyph-name",
-      "documentation": "The smufl-segno-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) segno character. The value is a SMuFL canonical glyph name that starts with segno.",
+      "documentation": "The smufl-segno-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) segno glyph. The value is a SMuFL canonical glyph name that starts with segno.",
       "base": [
          "smufl-glyph-name"
       ],
@@ -1030,7 +1030,7 @@
    },
    "smufl-lyrics-glyph-name": {
       "name": "smufl-lyrics-glyph-name",
-      "documentation": "The smufl-lyrics-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) lyrics elision character. The value is a SMuFL canonical glyph name that starts with lyrics.",
+      "documentation": "The smufl-lyrics-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) lyrics elision glyph. The value is a SMuFL canonical glyph name that starts with lyrics.",
       "base": [
          "smufl-glyph-name"
       ],
@@ -1099,7 +1099,7 @@
    },
    "smufl-wavy-line-glyph-name": {
       "name": "smufl-wavy-line-glyph-name",
-      "documentation": "The smufl-wavy-line-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) wavy line character. The value is a SMuFL canonical glyph name that either starts with wiggle, or begins with guitar and ends with VibratoStroke. This includes all the glyphs in the [Multi-segment lines range](https:\/\/www.w3.org\/2021\/03\/smufl14\/tables\/multi-segment-lines.html), excluding the beam glyphs.",
+      "documentation": "The smufl-wavy-line-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) wavy line glyph. The value is a SMuFL canonical glyph name that either starts with wiggle, or begins with guitar and ends with VibratoStroke. This includes all the glyphs in the [Multi-segment lines range](https:\/\/www.w3.org\/2021\/03\/smufl14\/tables\/multi-segment-lines.html), excluding the beam glyphs.",
       "base": [
          "smufl-glyph-name"
       ],
@@ -1454,7 +1454,7 @@
    },
    "staff-divide-symbol": {
       "name": "staff-divide-symbol",
-      "documentation": "The staff-divide-symbol type is used for staff division symbols. The down, up, and up-down values correspond to SMuFL code points U+E00B, U+E00C, and U+E00D respectively.",
+      "documentation": "The staff-divide-symbol type is used for staff division symbols. The down, up, and up-down values correspond to SMuFL glyphs staffDivideArrowDown, staffDivideArrowUp, and staffDivideArrowUpDown, respectively.",
       "base": [
          "xs:token"
       ],
@@ -1544,7 +1544,7 @@
    },
    "smufl-glyph-name": {
       "name": "smufl-glyph-name",
-      "documentation": "The smufl-glyph-name type is used for attributes that reference a specific Standard Music Font Layout (SMuFL) character. The value is a SMuFL canonical glyph name, not a code point. For instance, the value for a standard piano pedal mark would be keyboardPedalPed, not U+E650.",
+      "documentation": "The smufl-glyph-name type is used for attributes that reference a specific Standard Music Font Layout (SMuFL) glyph. The value is a SMuFL canonical glyph name, not a code point. For instance, the value for a standard piano pedal mark would be keyboardPedalPed, not U+E650.",
       "base": [
          "xs:NMTOKEN"
       ],

--- a/docs/src/data/elements-musicxml.json
+++ b/docs/src/data/elements-musicxml.json
@@ -3062,7 +3062,7 @@
          {
             "required": false,
             "name": "smufl",
-            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) character using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
+            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) glyph using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
             "type": "smufl-glyph-name"
          }
       ],
@@ -3442,7 +3442,7 @@
          {
             "required": false,
             "name": "smufl",
-            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) character using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
+            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) glyph using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
             "type": "smufl-glyph-name"
          }
       ],
@@ -3687,7 +3687,7 @@
          {
             "required": false,
             "name": "smufl",
-            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) character using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
+            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) glyph using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
             "type": "smufl-glyph-name"
          }
       ],
@@ -4541,7 +4541,7 @@
          {
             "required": false,
             "name": "smufl",
-            "documentation": "Specifies the exact Standard Music Font Layout (SMuFL) accidental character, using its SMuFL canonical glyph name.",
+            "documentation": "Specifies the exact Standard Music Font Layout (SMuFL) accidental glyph, using its SMuFL canonical glyph name.",
             "type": "smufl-accidental-glyph-name"
          }
       ],
@@ -4666,7 +4666,7 @@
          {
             "required": false,
             "name": "smufl",
-            "documentation": "Specifies a Standard Music Font Layout (SMuFL) accidental character by its canonical glyph name.",
+            "documentation": "Specifies a Standard Music Font Layout (SMuFL) accidental glyph by its canonical glyph name.",
             "type": "smufl-accidental-glyph-name"
          }
       ],
@@ -5296,7 +5296,7 @@
          {
             "required": false,
             "name": "smufl",
-            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) character using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
+            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) glyph using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
             "type": "smufl-glyph-name"
          }
       ],
@@ -7033,7 +7033,7 @@
          {
             "required": false,
             "name": "smufl",
-            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) character using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
+            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) glyph using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
             "type": "smufl-glyph-name"
          },
          {
@@ -10954,7 +10954,7 @@
          {
             "required": false,
             "name": "smufl",
-            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) character using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
+            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) glyph using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
             "type": "smufl-glyph-name"
          }
       ],
@@ -11066,7 +11066,7 @@
          {
             "required": false,
             "name": "smufl",
-            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) character using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
+            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) glyph using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
             "type": "smufl-glyph-name"
          }
       ],
@@ -11524,7 +11524,7 @@
          {
             "required": false,
             "name": "smufl",
-            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) character using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
+            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) glyph using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
             "type": "smufl-glyph-name"
          },
          {
@@ -11635,7 +11635,7 @@
          {
             "required": false,
             "name": "smufl",
-            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) character using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
+            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) glyph using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
             "type": "smufl-glyph-name"
          }
       ],
@@ -13439,7 +13439,7 @@
          {
             "required": false,
             "name": "smufl",
-            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) character using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
+            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) glyph using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
             "type": "smufl-glyph-name"
          }
       ],
@@ -14914,7 +14914,7 @@
          {
             "required": false,
             "name": "smufl",
-            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) character using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
+            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) glyph using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
             "type": "smufl-glyph-name"
          }
       ],
@@ -17865,7 +17865,7 @@
          {
             "required": false,
             "name": "smufl",
-            "documentation": "Specifies the exact Standard Music Font Layout (SMuFL) coda character used for the coda sign, using its SMuFL canonical glyph name.",
+            "documentation": "Specifies the exact Standard Music Font Layout (SMuFL) coda glyph used for the coda sign, using its SMuFL canonical glyph name.",
             "type": "smufl-coda-glyph-name"
          }
       ],
@@ -19752,7 +19752,7 @@
          {
             "required": false,
             "name": "smufl",
-            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) character using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
+            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) glyph using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
             "type": "smufl-glyph-name"
          }
       ],
@@ -21785,7 +21785,7 @@
          {
             "required": false,
             "name": "smufl",
-            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) character using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
+            "documentation": "Indicates a particular Standard Music Font Layout (SMuFL) glyph using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.",
             "type": "smufl-glyph-name"
          }
       ],

--- a/schema/common.mod
+++ b/schema/common.mod
@@ -248,7 +248,7 @@
 <!--
 	The smufl-glyph-name entity is used for attributes that
 	reference a specific Standard Music Font Layout (SMuFL)
-	character. The value is a SMuFL canonical glyph name,
+	glyph. The value is a SMuFL canonical glyph name,
 	not a code point. For instance, the value for a standard
 	piano pedal mark would be keyboardPedalPed, not U+E650.
 -->
@@ -782,7 +782,7 @@
 
 <!--
 	The smufl entity is used to indicate a particular Standard
-	Music Font Layout (SMuFL) character. Sometimes this is a
+	Music Font Layout (SMuFL) glyph. Sometimes this is a
 	formatting choice, and sometimes this is a refinement of
 	the semantic meaning of an element.
 -->

--- a/schema/musicxml.xsd
+++ b/schema/musicxml.xsd
@@ -548,14 +548,14 @@ As this example demonstrates, a reading program should be prepared to handle cas
 
 	<xs:simpleType name="smufl-glyph-name">
 		<xs:annotation>
-			<xs:documentation>The smufl-glyph-name type is used for attributes that reference a specific Standard Music Font Layout (SMuFL) character. The value is a SMuFL canonical glyph name, not a code point. For instance, the value for a standard piano pedal mark would be keyboardPedalPed, not U+E650.</xs:documentation>
+			<xs:documentation>The smufl-glyph-name type is used for attributes that reference a specific Standard Music Font Layout (SMuFL) glyph. The value is a SMuFL canonical glyph name, not a code point. For instance, the value for a standard piano pedal mark would be keyboardPedalPed, not U+E650.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:NMTOKEN"/>
 	</xs:simpleType>
 
 	<xs:simpleType name="smufl-accidental-glyph-name">
 		<xs:annotation>
-			<xs:documentation>The smufl-accidental-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) accidental character. The value is a SMuFL canonical glyph name that starts with one of the strings used at the start of glyph names for SMuFL accidentals.</xs:documentation>
+			<xs:documentation>The smufl-accidental-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) accidental glyph. The value is a SMuFL canonical glyph name that starts with one of the strings used at the start of glyph names for SMuFL accidentals.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="smufl-glyph-name">
 			<xs:pattern value="(acc|medRenFla|medRenNatura|medRenShar|kievanAccidental)(\c+)"/>
@@ -564,7 +564,7 @@ As this example demonstrates, a reading program should be prepared to handle cas
 
 	<xs:simpleType name="smufl-coda-glyph-name">
 		<xs:annotation>
-			<xs:documentation>The smufl-coda-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) coda character. The value is a SMuFL canonical glyph name that starts with coda.</xs:documentation>
+			<xs:documentation>The smufl-coda-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) coda glyph. The value is a SMuFL canonical glyph name that starts with coda.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="smufl-glyph-name">
 			<xs:pattern value="coda\c*"/>
@@ -573,7 +573,7 @@ As this example demonstrates, a reading program should be prepared to handle cas
 
 	<xs:simpleType name="smufl-lyrics-glyph-name">
 		<xs:annotation>
-			<xs:documentation>The smufl-lyrics-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) lyrics elision character. The value is a SMuFL canonical glyph name that starts with lyrics.</xs:documentation>
+			<xs:documentation>The smufl-lyrics-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) lyrics elision glyph. The value is a SMuFL canonical glyph name that starts with lyrics.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="smufl-glyph-name">
 			<xs:pattern value="lyrics\c+"/>
@@ -582,7 +582,7 @@ As this example demonstrates, a reading program should be prepared to handle cas
 
 	<xs:simpleType name="smufl-pictogram-glyph-name">
 		<xs:annotation>
-			<xs:documentation>The smufl-pictogram-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) percussion pictogram character. The value is a SMuFL canonical glyph name that starts with pict.</xs:documentation>
+			<xs:documentation>The smufl-pictogram-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) percussion pictogram glyph. The value is a SMuFL canonical glyph name that starts with pict.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="smufl-glyph-name">
 			<xs:pattern value="pict\c+"/>
@@ -591,7 +591,7 @@ As this example demonstrates, a reading program should be prepared to handle cas
 
 	<xs:simpleType name="smufl-segno-glyph-name">
 		<xs:annotation>
-			<xs:documentation>The smufl-segno-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) segno character. The value is a SMuFL canonical glyph name that starts with segno.</xs:documentation>
+			<xs:documentation>The smufl-segno-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) segno glyph. The value is a SMuFL canonical glyph name that starts with segno.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="smufl-glyph-name">
 			<xs:pattern value="segno\c*"/>
@@ -600,7 +600,7 @@ As this example demonstrates, a reading program should be prepared to handle cas
 
 	<xs:simpleType name="smufl-wavy-line-glyph-name">
 		<xs:annotation>
-			<xs:documentation>The smufl-wavy-line-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) wavy line character. The value is a SMuFL canonical glyph name that either starts with wiggle, or begins with guitar and ends with VibratoStroke. This includes all the glyphs in the [Multi-segment lines range](https://www.w3.org/2021/03/smufl14/tables/multi-segment-lines.html), excluding the beam glyphs.</xs:documentation>
+			<xs:documentation>The smufl-wavy-line-glyph-name type is used to reference a specific Standard Music Font Layout (SMuFL) wavy line glyph. The value is a SMuFL canonical glyph name that either starts with wiggle, or begins with guitar and ends with VibratoStroke. This includes all the glyphs in the [Multi-segment lines range](https://www.w3.org/2021/03/smufl14/tables/multi-segment-lines.html), excluding the beam glyphs.</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="smufl-glyph-name">
 			<xs:pattern value="(wiggle\c+)|(guitar\c*VibratoStroke)"/>
@@ -3966,11 +3966,11 @@ By default, all these attributes are set to yes. If print-object is set to no, t
 
 	<xs:attributeGroup name="smufl">
 		<xs:annotation>
-			<xs:documentation>The smufl attribute group is used to indicate a particular Standard Music Font Layout (SMuFL) character. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.</xs:documentation>
+			<xs:documentation>The smufl attribute group is used to indicate a particular Standard Music Font Layout (SMuFL) glyph. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.</xs:documentation>
 		</xs:annotation>
 		<xs:attribute name="smufl" type="smufl-glyph-name">
 			<xs:annotation>
-				<xs:documentation>Indicates a particular Standard Music Font Layout (SMuFL) character using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.</xs:documentation>
+				<xs:documentation>Indicates a particular Standard Music Font Layout (SMuFL) glyph using its canonical glyph name. Sometimes this is a formatting choice, and sometimes this is a refinement of the semantic meaning of an element.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 	</xs:attributeGroup>
@@ -4425,7 +4425,7 @@ While often numeric, it does not have to be. Non-numeric values are typically us
 				<xs:attributeGroup ref="text-formatting"/>
 				<xs:attribute name="smufl" type="smufl-accidental-glyph-name">
 					<xs:annotation>
-						<xs:documentation>Specifies the exact Standard Music Font Layout (SMuFL) accidental character, using its SMuFL canonical glyph name.</xs:documentation>
+						<xs:documentation>Specifies the exact Standard Music Font Layout (SMuFL) accidental glyph, using its SMuFL canonical glyph name.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 			</xs:extension>
@@ -4440,7 +4440,7 @@ While often numeric, it does not have to be. Non-numeric values are typically us
 		<xs:attributeGroup ref="optional-unique-id"/>
 		<xs:attribute name="smufl" type="smufl-coda-glyph-name">
 			<xs:annotation>
-				<xs:documentation>Specifies the exact Standard Music Font Layout (SMuFL) coda character used for the coda sign, using its SMuFL canonical glyph name.</xs:documentation>
+				<xs:documentation>Specifies the exact Standard Music Font Layout (SMuFL) coda glyph used for the coda sign, using its SMuFL canonical glyph name.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 	</xs:complexType>
@@ -5332,7 +5332,7 @@ The &lt;chromatic&gt; element in a &lt;part-transpose&gt; element will usually h
 			<xs:extension base="accidental-value">
 				<xs:attribute name="smufl" type="smufl-accidental-glyph-name">
 					<xs:annotation>
-						<xs:documentation>Specifies a Standard Music Font Layout (SMuFL) accidental character by its canonical glyph name.</xs:documentation>
+						<xs:documentation>Specifies a Standard Music Font Layout (SMuFL) accidental glyph by its canonical glyph name.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 			</xs:extension>


### PR DESCRIPTION
MusicXML always uses glyph names to specify SMuFL glyphs and never character codes (except while talking about SMuFL ranges), which is good.  It thus makes sense to not conflate the two terms 'glyph' and 'character' by always using the term 'glyph' while talking about SMuFL entities.

This avoids confusion, especially because the character codes used by SMuFL lie in the PUAs (Private Unicode Areas), which are *not* standardized by Unicode and thus are shared by other projects that also use these character code ranges (for example, the Medieval Unicode Font Initiative, https://www.mufi.info).